### PR TITLE
add extra styles

### DIFF
--- a/pressbooks.scss
+++ b/pressbooks.scss
@@ -206,6 +206,44 @@ $text-transform-values: (
   'normal-case': none,
 );
 
+$colors: (
+  'white': #fff,
+  'learning-obj': #c5bdaa,
+  'try-it': #3c2a21,
+  'example': #eae8d7,
+  'challenge-question': #eae8d7,
+  'accordion': #f0f0f0,
+  'transparent': transparent,
+);
+
+$width-values: (
+  "1-2": 50%,
+  "1-3": 33.3333%,
+  "2-3": 66.6667%,
+  "1-4": 25%,
+  "2-4": 50%,
+  "3-4": 75%,
+  "1-5": 20%,
+  "2-5": 40%,
+  "3-5": 60%,
+  "4-5": 80%,
+  "full": 100%,
+  "auto": auto,
+  "min": min-content,
+  "max": max-content,
+  "0": 0,
+  "px": 1px,
+  "0.5": 0.125rem,
+  "1": 0.25rem,
+  "2": 0.5rem,
+  "4": 1rem,
+  "8": 2rem,
+  "10": 2.5rem,
+  "16": 4rem,
+  "32": 8rem,
+  "96": 24rem
+);
+
 $font-size-values: (
   'xs': 0.75rem,
   'sm': 0.875rem,

--- a/pressbooks.scss
+++ b/pressbooks.scss
@@ -308,6 +308,7 @@ $important-suffix: "\\\\!";
 @include generate-utilities('border-l', 'border-left-width', $pixel-values);
 @include generate-utilities('border-b', 'border-bottom-width', $pixel-values);
 @include generate-utilities('border-t', 'border-top-width', $pixel-values);
+@include generate-utilities('border-color', 'border-color', $colors);
 @include generate-utilities('rounded', 'border-radius', $radius-values);
 @include generate-utilities('shadow', 'box-shadow', $shadow-values);
 @include generate-utilities('inset-shadow', 'box-shadow', $shadow-inset-values);
@@ -325,6 +326,9 @@ $important-suffix: "\\\\!";
 @include generate-utilities('overflow', 'overflow', $overflow-values);
 @include generate-utilities('overflow-x', 'overflow-x', $overflow-values);
 @include generate-utilities('overflow-y', 'overflow-y', $overflow-values);
+@include generate-utilities('color', 'color', $colors);
+@include generate-utilities('background', 'background-color', $colors);
+@include generate-utilities('w', 'width', $width-values);
 
 /* Global Styles */
 
@@ -342,8 +346,3 @@ $important-suffix: "\\\\!";
 .mjx-mfrac {
   font-size: 1.5rem;
 }
-@include generate-utilities('text', 'text-transform', $text-transform-values);
-@include generate-utilities('color', 'color', $colors);
-@include generate-utilities('background', 'background-color', $colors);
-@include generate-utilities('border-color', 'border-color', $colors);
-@include generate-utilities('w', 'width', $width-values);

--- a/pressbooks.scss
+++ b/pressbooks.scss
@@ -1,9 +1,9 @@
 $breakpoints: (
-  'sm': 576px,
-  'md': 768px,
-  'lg': 992px,
-  'xl': 1200px,
-  '2xl': 1400px,
+  'sm': 40rem,
+  'md': 48rem,
+  'lg': 64rem,
+  'xl': 80rem,
+  '2xl': 96rem,
 );
 
 $shadow-values: (
@@ -100,6 +100,14 @@ $pixel-values: (
   '1': 1px,
   '2': 2px,
   '4': 4px,
+  '8': 8px,
+);
+
+$overflow-values: (
+  'auto': auto,
+  'hidden': hidden,
+  'visible': visible,
+  'scroll': scroll,
 );
 
 $grid-cols-values: (
@@ -193,6 +201,21 @@ $text-transform-values: (
   'normal-case': none,
 );
 
+$font-size-values: (
+  'xs': 0.75rem,
+  'sm': 0.875rem,
+  'base': 1rem,
+  'lg': 1.125rem,
+  'xl': 1.25rem,
+  '2xl': 1.5rem,
+  '3xl': 1.875rem,
+  '4xl': 2.25rem,
+  '5xl': 3rem,
+  '6xl': 3.75rem,
+  '7xl': 4.5rem,
+  '8xl': 6rem,
+  '9xl': 8rem,
+);
 
 //  NOTE: the php-sass compiler automatically removes backslashes from its output,
 // so we need to double-escape the double backslash
@@ -276,11 +299,17 @@ $important-suffix: "\\\\!";
 @include generate-utilities('gap-y', 'row-gap', $unit-values);
 @include generate-utilities('indent', 'text-indent', $unit-values);
 @include generate-utilities('border', 'border-width', $pixel-values);
+@include generate-utilities('border-r', 'border-right-width', $pixel-values);
+@include generate-utilities('border-l', 'border-left-width', $pixel-values);
+@include generate-utilities('border-b', 'border-bottom-width', $pixel-values);
+@include generate-utilities('border-t', 'border-top-width', $pixel-values);
 @include generate-utilities('rounded', 'border-radius', $radius-values);
 @include generate-utilities('shadow', 'box-shadow', $shadow-values);
 @include generate-utilities('inset-shadow', 'box-shadow', $shadow-inset-values);
 @include generate-utilities('font', 'font-weight', $font-weight-values);
 @include generate-utilities('text', 'text-align', $text-align-values);
+@include generate-utilities('text', 'font-size', $font-size-values);
+@include generate-utilities('text', 'text-transform', $text-transform-values);
 @include generate-utilities('blur', 'filter', $blur-values);
 @include generate-utilities('cursor', 'cursor', $cursor-values);
 @include generate-utilities('transition', 'transition', $transition-values);
@@ -288,4 +317,23 @@ $important-suffix: "\\\\!";
 @include generate-utilities('delay', 'transition-delay', $transition-unit-values);
 @include generate-utilities('ease', 'transition-timing-function', $transition-values);
 @include generate-utilities('list', 'list-style-type', $list-style-values);
-@include generate-utilities('text', 'text-transform', $text-transform-values);
+@include generate-utilities('overflow', 'overflow', $overflow-values);
+@include generate-utilities('overflow-x', 'overflow-x', $overflow-values);
+@include generate-utilities('overflow-y', 'overflow-y', $overflow-values);
+
+/* Global Styles */
+
+*,
+:after,
+:before,
+::backdrop {
+  box-sizing: border-box;
+  border: 0 solid;
+  margin: 0;
+  padding: 0;
+}
+
+//  NOTE: Increase the `font-size` of mathjax fraction element
+.mjx-mfrac {
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
This PR adds extra styles to the on-going implementation of the oer-tailwind styling framework. New attributes:

- `overflow` (`overflow-x`, `overflow-y`, `overflow`)
- `font-size` (`xs` to `9xl`)